### PR TITLE
Add null coalescing for startDateTime and endDateTime in LTI_Lineitem

### DIFF
--- a/src/lti/LTI_Lineitem.php
+++ b/src/lti/LTI_Lineitem.php
@@ -19,8 +19,8 @@ class LTI_Lineitem {
         $this->label = $lineitem["label"];
         $this->resource_id = $lineitem["resourceId"];
         $this->tag = $lineitem["tag"];
-        $this->start_date_time = $lineitem["startDateTime"];
-        $this->end_date_time = $lineitem["endDateTime"];
+        $this->start_date_time = $lineitem["startDateTime"] ?? null;
+        $this->end_date_time = $lineitem["endDateTime"] ?? null;
     }
 
     /**


### PR DESCRIPTION
When creating a LineItem object, if the datetime fields are not set, the response does not include datetime values. To handle this case, I have implemented a null check in the constructor to ensure that the datetime fields are correctly initialized even if they are not set during creation.